### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ tts = TTS("TeraTTS/natasha-g2p-vits", add_time_to_end=1.0, tokenizer_load_dict=T
 
 
 # 'length_scale' можно использовать для замедления аудио для лучшего звучания (по умолчанию 1.1, указано здесь для примера)
-audio = tts(text, lenght_scale=1.1)  # Создать аудио. Можно добавить ударения, используя '+'
+audio = tts(text, length_scale=1.1)  # Создать аудио. Можно добавить ударения, используя '+'
 tts.play_audio(audio)  # Воспроизвести созданное аудио
 tts.save_wav(audio, "./test.wav")  # Сохранить аудио в файл
 
 
 # Создать аудио и сразу его воспроизвести
-tts(text, play=True, lenght_scale=1.1)
+tts(text, play=True, length_scale=1.1)
 
 ```

--- a/TeraTTS/infer_onnx.py
+++ b/TeraTTS/infer_onnx.py
@@ -64,7 +64,7 @@ class TTS:
         ret = num2words(match, lang ='ru')
         return ret 
     
-    def __call__(self, text: str, play = False, lenght_scale=1.2):
+    def __call__(self, text: str, play = False, length_scale=1.2):
         if self.preprocess_trans:
             text = translit(text, 'ru')
         
@@ -74,7 +74,7 @@ class TTS:
         text = np.expand_dims(np.array(phoneme_ids, dtype=np.int64), 0)
         text_lengths = np.array([text.shape[1]], dtype=np.int64)
         scales = np.array(
-            [0.667, lenght_scale, 0.8],
+            [0.667, length_scale, 0.8],
             dtype=np.float32,
         )
         audio = self.model.run(

--- a/example.py
+++ b/example.py
@@ -19,10 +19,10 @@ tts = TTS("TeraTTS/natasha-g2p-vits", add_time_to_end=1.0, tokenizer_load_dict=T
 
 
 # 'length_scale' можно использовать для замедления аудио для лучшего звучания (по умолчанию 1.1, указано здесь для примера)
-audio = tts(text, lenght_scale=1.1)  # Создать аудио. Можно добавить ударения, используя '+'
+audio = tts(text, length_scale=1.1)  # Создать аудио. Можно добавить ударения, используя '+'
 tts.play_audio(audio)  # Воспроизвести созданное аудио
 tts.save_wav(audio, "./test.wav")  # Сохранить аудио в файл
 
 
 # Создать аудио и сразу его воспроизвести
-tts(text, play=True, lenght_scale=1.1)
+tts(text, play=True, length_scale=1.1)


### PR DESCRIPTION
Теперь length везде одинаково написан, а то внезапные ошибки:
Error: __call__() got an unexpected keyword argument 'length_scale'